### PR TITLE
Split the Key class into HMAC/GSSAPI types and allow it to be callable

### DIFF
--- a/dns/message.py
+++ b/dns/message.py
@@ -517,7 +517,7 @@ class Message:
         only used if *keyring* is a ``dict``, and the key entry is a ``bytes``.
         """
 
-        if isinstance(keyring, dns.tsig.Key):
+        if isinstance(keyring, dns.tsig.HMACTSigKey):
             self.keyring = keyring
         else:
             if isinstance(keyname, str):
@@ -526,7 +526,7 @@ class Message:
                 keyname = next(iter(keyring))
             key = keyring[keyname]
             if isinstance(key, bytes):
-                key = dns.tsig.Key(keyname, key, algorithm)
+                key = dns.tsig.HMACTSigKey(keyname, key, algorithm)
             self.keyring = key
         if original_id is None:
             original_id = self.id
@@ -919,7 +919,9 @@ class _WireReader:
                 if isinstance(self.keyring, dict):
                     key = self.keyring.get(absolute_name)
                     if isinstance(key, bytes):
-                        key = dns.tsig.Key(absolute_name, key, rd.algorithm)
+                        key = dns.tsig.HMACTSigKey(absolute_name, key, rd.algorithm)
+                    elif callable(key):
+                        key = key(self.message)
                 else:
                     key = self.keyring
                 if key is None:

--- a/dns/message.py
+++ b/dns/message.py
@@ -517,7 +517,7 @@ class Message:
         only used if *keyring* is a ``dict``, and the key entry is a ``bytes``.
         """
 
-        if isinstance(keyring, dns.tsig.HMACTSigKey):
+        if isinstance(keyring, dns.tsig.Key):
             self.keyring = keyring
         else:
             if isinstance(keyname, str):
@@ -526,7 +526,7 @@ class Message:
                 keyname = next(iter(keyring))
             key = keyring[keyname]
             if isinstance(key, bytes):
-                key = dns.tsig.HMACTSigKey(keyname, key, algorithm)
+                key = dns.tsig.Key.create(keyname, key, algorithm)
             self.keyring = key
         if original_id is None:
             original_id = self.id
@@ -919,7 +919,7 @@ class _WireReader:
                 if isinstance(self.keyring, dict):
                     key = self.keyring.get(absolute_name)
                     if isinstance(key, bytes):
-                        key = dns.tsig.HMACTSigKey(absolute_name, key, rd.algorithm)
+                        key = dns.tsig.Key.create(absolute_name, key, rd.algorithm)
                     elif callable(key):
                         key = key(self.message)
                 else:

--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -179,10 +179,10 @@ class Renderer:
 
         s = self.output.getvalue()
 
-        if isinstance(secret, dns.tsig.Key):
+        if isinstance(secret, dns.tsig.HMACTSigKey):
             key = secret
         else:
-            key = dns.tsig.Key(keyname, secret, algorithm)
+            key = dns.tsig.HMACTSigKey(keyname, secret, algorithm)
         tsig = dns.message.Message._make_tsig(keyname, algorithm, 0, fudge,
                                               b'', id, tsig_error, other_data)
         (tsig, _) = dns.tsig.sign(s, key, tsig[0], int(time.time()),
@@ -202,10 +202,10 @@ class Renderer:
 
         s = self.output.getvalue()
 
-        if isinstance(secret, dns.tsig.Key):
+        if isinstance(secret, dns.tsig.HMACTSigKey):
             key = secret
         else:
-            key = dns.tsig.Key(keyname, secret, algorithm)
+            key = dns.tsig.HMACTSigKey(keyname, secret, algorithm)
         tsig = dns.message.Message._make_tsig(keyname, algorithm, 0, fudge,
                                               b'', id, tsig_error, other_data)
         (tsig, ctx) = dns.tsig.sign(s, key, tsig[0], int(time.time()),

--- a/dns/renderer.py
+++ b/dns/renderer.py
@@ -179,10 +179,10 @@ class Renderer:
 
         s = self.output.getvalue()
 
-        if isinstance(secret, dns.tsig.HMACTSigKey):
+        if isinstance(secret, dns.tsig.Key):
             key = secret
         else:
-            key = dns.tsig.HMACTSigKey(keyname, secret, algorithm)
+            key = dns.tsig.Key.create(keyname, secret, algorithm)
         tsig = dns.message.Message._make_tsig(keyname, algorithm, 0, fudge,
                                               b'', id, tsig_error, other_data)
         (tsig, _) = dns.tsig.sign(s, key, tsig[0], int(time.time()),
@@ -202,10 +202,10 @@ class Renderer:
 
         s = self.output.getvalue()
 
-        if isinstance(secret, dns.tsig.HMACTSigKey):
+        if isinstance(secret, dns.tsig.Key):
             key = secret
         else:
-            key = dns.tsig.HMACTSigKey(keyname, secret, algorithm)
+            key = dns.tsig.Key.create(keyname, secret, algorithm)
         tsig = dns.message.Message._make_tsig(keyname, algorithm, 0, fudge,
                                               b'', id, tsig_error, other_data)
         (tsig, ctx) = dns.tsig.sign(s, key, tsig[0], int(time.time()),

--- a/dns/tsigkeyring.py
+++ b/dns/tsigkeyring.py
@@ -33,10 +33,10 @@ def from_text(textring):
     for (name, value) in textring.items():
         name = dns.name.from_text(name)
         if isinstance(value, str):
-            keyring[name] = dns.tsig.Key(name, value).secret
+            keyring[name] = dns.tsig.HMACTSigKey(name, value).secret
         else:
             (algorithm, secret) = value
-            keyring[name] = dns.tsig.Key(name, secret, algorithm)
+            keyring[name] = dns.tsig.HMACTSigKey(name, secret, algorithm)
     return keyring
 
 
@@ -55,10 +55,13 @@ def to_text(keyring):
         if isinstance(key, bytes):
             textring[name] = b64encode(key)
         else:
-            if isinstance(key.secret, bytes):
-                text_secret = b64encode(key.secret)
-            else:
-                text_secret = str(key.secret)
+            if isinstance(key, dns.tsig.HMACTSigKey):
+                if isinstance(key.secret, bytes):
+                    text_secret = b64encode(key.secret)
+                else:
+                    text_secret = str(key.secret)
+            elif isinstance(key, dns.tsig.GSSTSigKey):
+                text_secret = repr(key)
 
             textring[name] = (key.algorithm.to_text(), text_secret)
     return textring

--- a/dns/tsigkeyring.py
+++ b/dns/tsigkeyring.py
@@ -33,10 +33,10 @@ def from_text(textring):
     for (name, value) in textring.items():
         name = dns.name.from_text(name)
         if isinstance(value, str):
-            keyring[name] = dns.tsig.HMACTSigKey(name, value).secret
+            keyring[name] = dns.tsig.Key.create(name, value).secret
         else:
             (algorithm, secret) = value
-            keyring[name] = dns.tsig.HMACTSigKey(name, secret, algorithm)
+            keyring[name] = dns.tsig.Key.create(name, secret, algorithm)
     return keyring
 
 
@@ -48,20 +48,10 @@ def to_text(keyring):
     @rtype: dict"""
 
     textring = {}
-    def b64encode(secret):
-        return base64.encodebytes(secret).decode().rstrip()
     for (name, key) in keyring.items():
         name = name.to_text()
         if isinstance(key, bytes):
-            textring[name] = b64encode(key)
+            textring[name] = dns.tsig.b64encode(key)
         else:
-            if isinstance(key, dns.tsig.HMACTSigKey):
-                if isinstance(key.secret, bytes):
-                    text_secret = b64encode(key.secret)
-                else:
-                    text_secret = str(key.secret)
-            elif isinstance(key, dns.tsig.GSSTSigKey):
-                text_secret = repr(key)
-
-            textring[name] = (key.algorithm.to_text(), text_secret)
+            textring[name] = (key.algorithm.to_text(), key.to_text())
     return textring

--- a/tests/test_tsigkeyring.py
+++ b/tests/test_tsigkeyring.py
@@ -18,7 +18,7 @@ old_text_keyring = {
     'keyname.' : 'NjHwPsMKjdN++dOfE5iAiQ=='
 }
 
-key = dns.tsig.Key('keyname.', 'NjHwPsMKjdN++dOfE5iAiQ==')
+key = dns.tsig.HMACTSigKey('keyname.', 'NjHwPsMKjdN++dOfE5iAiQ==')
 
 rich_keyring = { key.name : key }
 


### PR DESCRIPTION
Split the Key class into HMAC/GSSAPI types and allow it to be callable - this fixes a few things (e.g. get_context no longer needs to exist as a choice - we already know the key type), and allows keys to be callable() to support making a key choice based on an incoming message (or in this case, absorb a key into a GSSAPI context based on an incoming TKEY request/response.